### PR TITLE
bugfix :focus for btn

### DIFF
--- a/src/sass/structure/_products.scss
+++ b/src/sass/structure/_products.scss
@@ -269,12 +269,12 @@
   height: 40px;
   border: 0px;
   border-radius: 50%;
-  background-color: #ffffff;
+  background-color: $first-color;
 
   @include transitions(background-color);
 
   &:hover,
-  &:focus {
+  &.is-open:focus {
     background-color: #aaaaaa;
   }
 


### PR DESCRIPTION
залишила фокус на кнопці лише тоді, коли до неї по скрипту додається клас is-open